### PR TITLE
Reduced netty usage to the required artifact.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-            <version>4.1.42.Final</version>
+            <artifactId>netty-codec-http</artifactId>
+            <version>4.1.47.Final</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
`netty-all` bundles a wide array of netty dependencies, however only a small sub-section is required for this library. Some of the surplus classes can lead to unplanned changes in runtime behaviour, such as dynamic loading of os-native funtionality.

Co-authored-by: Muad Mohamed <muadhabdullahi@gmail.com>
Co-authored-by: Pierre-Yves B <PyvesDev@gmail.com>